### PR TITLE
feat|admin페이지 완성

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -6,7 +6,7 @@ const createJestConfig = nextJest({ dir: "./" });
 const customJestConfig = {
   testEnvironment: "jest-environment-jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
-  moduleNameMapper: { "^@/(.*)$": "<rootDir>/$1" },
+  moduleNameMapper: { "^@/(.*)$": "<rootDir>/src/$1" },
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/client/src/app/admin/page.tsx
+++ b/client/src/app/admin/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { IModerationItem } from "@/components/organisms/ModerationQueue/type/ModerationQueue.types";
+import { ISessionRow } from "@/components/organisms/SessionTable/type/SessionTable.types";
+import { IAdminUser } from "@/components/organisms/UserSearchPanel/type/UserSearchPanel.types";
+import { AdminPage } from "@/components/page/AdminPage/AdminPage";
+
+export default function Page() {
+  const users: ReadonlyArray<IAdminUser> = [
+    { id: "u_1", email: "hana@example.com", name: "Hana", status: "active" },
+    { id: "u_2", email: "alex@world.com", name: "Alex", status: "active" },
+    { id: "u_3", email: "li@cn.cn", name: "Li", status: "banned" },
+  ];
+
+  const sessions: ReadonlyArray<ISessionRow> = Array.from({ length: 6 }).map((_, i) => ({
+    id: `s_${100 + i}`,
+    user: i % 2 ? "Alex" : "Hana",
+    start: `${8 + i}:0${i}`,
+    pages: 2 + (i % 5),
+    last: i % 2 ? "/course/intro" : "/community",
+    utm: i % 3 === 0 ? "google/brand" : undefined,
+  }));
+
+  const moderationQueue: ReadonlyArray<IModerationItem> = [
+    { id: "p_1", title: "은행 계좌 개설 팁", author: "Hana", flags: 3 },
+    { id: "p_2", title: "체류지 변경 후기", author: "Alex", flags: 2 },
+    { id: "p_3", title: "병원 접수 표현", author: "Li", flags: 5 },
+  ];
+
+  return <AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />;
+}

--- a/client/src/components/features/AdminLayout/AdminLayout.tsx
+++ b/client/src/components/features/AdminLayout/AdminLayout.tsx
@@ -1,0 +1,99 @@
+import { IAdminLayoutProps } from "./type/AdminLayout.types";
+
+/**
+ * 관리자 페이지 공통 레이아웃 템플릿
+ * @example
+ * <AdminLayout
+ *   title="Admin Dashboard"
+ *   subtitle="지난 7일 요약"
+ *   breadcrumbs={[
+ *     { label: 'Home', href: '/' },
+ *     { label: 'Admin' },
+ *   ]}
+ *   actions={
+ *     <div className="flex gap-2">
+ *       <button className="rounded-md bg-black px-3 py-1 text-white">New</button>
+ *       <button className="rounded-md bg-neutral-200 px-3 py-1">Export</button>
+ *     </div>
+ *   }
+ * >
+ *   <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+ *      ...KPIs / Panels...
+ *   </div>
+ * </AdminLayout>
+ */
+export default function AdminLayout({
+  title,
+  subtitle,
+  actions,
+  breadcrumbs,
+  onBack,
+  children,
+  withContainer = true,
+  className = "",
+}: IAdminLayoutProps) {
+  const Container = withContainer
+    ? ({ children: c }: { children: React.ReactNode }) => (
+        <div className="mx-auto max-w-7xl p-4 md:p-6">{c}</div>
+      )
+    : ({ children: c }: { children: React.ReactNode }) => <>{c}</>;
+  return (
+    <div className={`min-h-screen ${className}`}>
+      <header
+        className="border-b bg-white/70 backdrop-blur"
+        role="banner"
+        aria-label="admin header"
+      >
+        <Container>
+          <div className="flex flex-col gap-3">
+            {breadcrumbs && breadcrumbs.length > 0 && (
+              <nav aria-label="Breadcrumb">
+                <ol className="flex flex-wrap items-center gap-1 text-sm text-neutral-500">
+                  {breadcrumbs.map((b, i) => (
+                    <li key={b.label} className="flex items-center gap-1">
+                      {b.href ? (
+                        <a href={b.href} className="underline-offset-2 hover:underline">
+                          {b.label}
+                        </a>
+                      ) : (
+                        <span aria-current={i === breadcrumbs.length - 1 ? "page" : undefined}>
+                          {b.label}
+                        </span>
+                      )}
+                      {i < breadcrumbs.length - 1 && <span>›</span>}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-start gap-2">
+                {onBack && (
+                  <button
+                    type="button"
+                    aria-label="Go back"
+                    onClick={onBack}
+                    className="mt-0.5 rounded-full bg-neutral-200 px-2 py-1 text-sm"
+                    title="Back"
+                  >
+                    ←
+                  </button>
+                )}
+                <div>
+                  <h1 className="text-xl font-semibold">{title}</h1>
+                  {subtitle && <p className="text-sm text-neutral-500">{subtitle}</p>}
+                </div>
+              </div>
+              {actions && <div className="shrink-0">{actions}</div>}
+            </div>
+          </div>
+        </Container>
+      </header>
+
+      <main role="main" aria-label="admin content">
+        <Container>{children}</Container>
+      </main>
+    </div>
+  );
+}

--- a/client/src/components/features/AdminLayout/__test__/AdminLayout.test.tsx
+++ b/client/src/components/features/AdminLayout/__test__/AdminLayout.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { IBreadcrumbItem } from "../type/AdminLayout.types";
+import AdminLayout from "../AdminLayout";
+
+describe("AdminLayout", () => {
+  const breadcrumbs: IBreadcrumbItem[] = [{ label: "Home", href: "/" }, { label: "Admin" }];
+
+  it("제목/부제, 헤더/메인 역할이 올바르게 렌더링된다", () => {
+    render(
+      <AdminLayout title="Admin Dashboard" subtitle="지난 7일 요약">
+        <div>contents</div>
+      </AdminLayout>
+    );
+
+    // 제목/부제
+    expect(screen.getByRole("heading", { name: "Admin Dashboard" })).toBeInTheDocument();
+    expect(screen.getByText("지난 7일 요약")).toBeInTheDocument();
+
+    // 접근성 역할
+    expect(screen.getByRole("banner", { name: /admin header/i })).toBeInTheDocument();
+    expect(screen.getByRole("main", { name: /admin content/i })).toBeInTheDocument();
+
+    // 메인 콘텐츠
+    expect(screen.getByText("contents")).toBeInTheDocument();
+  });
+
+  it("브레드크럼을 렌더링하고 마지막 항목은 aria-current='page'로 표시한다", () => {
+    render(
+      <AdminLayout title="Admin" breadcrumbs={breadcrumbs}>
+        <div />
+      </AdminLayout>
+    );
+
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(nav).toBeInTheDocument();
+
+    // 첫 항목은 링크, 두 번째(마지막)는 span + aria-current='page'
+    const ol = within(nav).getByRole("list");
+    const items = within(ol).getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+
+    // 첫 번째 항목: 링크
+    expect(within(items[0]).getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+
+    // 두 번째 항목: 현재 페이지(span)
+    const last = within(items[1]).getByText("Admin");
+    expect(last.tagName.toLowerCase()).toBe("span");
+    expect(last).toHaveAttribute("aria-current", "page");
+
+    // 구분자 개수 = 항목수 - 1
+    const separators = within(ol).getAllByText("›");
+    expect(separators).toHaveLength(breadcrumbs.length - 1);
+  });
+
+  it("onBack이 전달되면 'Go back' 버튼을 렌더링하고 클릭 시 콜백을 호출한다", () => {
+    const handleBack = jest.fn();
+
+    render(
+      <AdminLayout title="Admin" onBack={handleBack}>
+        <div />
+      </AdminLayout>
+    );
+
+    const backBtn = screen.getByRole("button", { name: /go back/i });
+    expect(backBtn).toBeInTheDocument();
+
+    fireEvent.click(backBtn);
+    expect(handleBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("actions 영역을 우측 상단에 렌더링한다", () => {
+    render(
+      <AdminLayout
+        title="Admin"
+        actions={
+          <div>
+            <button type="button">New</button>
+            <button type="button">Export</button>
+          </div>
+        }
+      >
+        <div />
+      </AdminLayout>
+    );
+
+    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
+  });
+
+  it("onBack이 전달되면 'Go back' 버튼을 렌더링하고 클릭 시 콜백을 호출한다", () => {
+    const handleBack = jest.fn();
+
+    render(
+      <AdminLayout title="Admin" onBack={handleBack}>
+        <div />
+      </AdminLayout>
+    );
+
+    const backBtn = screen.getByRole("button", { name: /go back/i });
+    expect(backBtn).toBeInTheDocument();
+
+    fireEvent.click(backBtn);
+    expect(handleBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("actions 영역을 우측 상단에 렌더링한다", () => {
+    render(
+      <AdminLayout
+        title="Admin"
+        actions={
+          <div>
+            <button type="button">New</button>
+            <button type="button">Export</button>
+          </div>
+        }
+      >
+        <div />
+      </AdminLayout>
+    );
+
+    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/features/AdminLayout/type/AdminLayout.types.ts
+++ b/client/src/components/features/AdminLayout/type/AdminLayout.types.ts
@@ -1,0 +1,34 @@
+/**
+ * 브레드크럼 항목 모델
+ * @interface
+ * @param {string} label - 표시 텍스트
+ * @param {string} href - 링크 URL (없으면 단순 텍스트)
+ */
+export interface IBreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+/**
+ * 컴포넌트 속성
+ * @interface
+ * @param {string} title - 페이지 상단의 큰 제목
+ * @param {string} subtitle - 보조 설명
+ * @param {React.ReactNode} action - 우측 상단 액션 영역에 렌더할 노드(버튼 그룹 등, 옵션
+ * @param {ReadonlyArray<IBreadcrumbItem>} breadcrumbs - 브레드크럼 목록(옵션)
+ * @param {(ev:React.MouseEvent<HTMLButtonElement>) => void} onBack
+ * 상단 좌측에 "뒤로가기" 아이콘/버튼이 필요할 때 콜백 제공(옵션)
+ * ev: 클릭 이벤트
+ * @param {React.ReactNode} children - 본 콘텐츠
+ * @param {boolean} withContainer - 내부 컨테이너를 사용할지 여부
+ */
+export interface IAdminLayoutProps {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  breadcrumbs?: ReadonlyArray<IBreadcrumbItem>;
+  onBack?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
+  children: React.ReactNode;
+  withContainer?: boolean;
+  className?: string;
+}

--- a/client/src/components/organisms/ModerationQueue/ModerationQueue.tsx
+++ b/client/src/components/organisms/ModerationQueue/ModerationQueue.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Button from "@/components/atoms/Button/Button";
+import { IModerationQueueProps } from "./type/ModerationQueue.types";
+
+/**
+ * 신고 누적 콘텐츠를 처리하는 모더레이션 큐
+ * @example
+ * const queue: IModerationItem[] = [
+ *   { id: 'p_1', title: '은행 계좌 개설 팁', author: 'Hana', flags: 3 },
+ *   { id: 'p_2', title: '체류지 변경 후기', author: 'Alex', flags: 2 },
+ * ];
+ *
+ * <ModerationQueue
+ *   items={queue}
+ *   onAction={(id, action) => console.log('moderate', id, action)}
+ * />
+ */
+export default function ModerationQueue({
+  items,
+  onAction,
+  emptyText = "No pending items",
+  className = "",
+}: IModerationQueueProps) {
+  return (
+    <ul className={`space-y-2 ${className}`} role="list">
+      {items.length === 0 ? (
+        <li className="text-sm text-neutral-500">{emptyText}</li>
+      ) : (
+        items.map(i => (
+          <li
+            key={i.id}
+            className="flex items-center justify-between rounded-lg border bg-neutral-50 p-3"
+          >
+            <div>
+              <div className="font-medium">{i.title}</div>
+              <div className="text-xs text-neutral-500">
+                by {i.author} · flags {i.flags}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="primary"
+                onClick={() => onAction(i.id, "approve")}
+                aria-label={`Approve ${i.title}`}
+              >
+                Approve
+              </Button>
+              <Button
+                variant="warning"
+                onClick={() => onAction(i.id, "hide")}
+                aria-label={`Hide ${i.title}`}
+              >
+                Hide
+              </Button>
+              <Button
+                variant="danger"
+                onClick={() => onAction(i.id, "remove")}
+                aria-label={`Remove ${i.title}`}
+              >
+                Remove
+              </Button>
+            </div>
+          </li>
+        ))
+      )}
+    </ul>
+  );
+}

--- a/client/src/components/organisms/ModerationQueue/__test__/ModerationQueue.test.tsx
+++ b/client/src/components/organisms/ModerationQueue/__test__/ModerationQueue.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { IModerationItem } from "../type/ModerationQueue.types";
+import ModerationQueue from "../ModerationQueue";
+
+describe("ModerationQueue", () => {
+  const items: IModerationItem[] = [
+    { id: "p_1", title: "은행 계좌 개설 팁", author: "Hana", flags: 3 },
+    { id: "p_2", title: "체류지 변경 후기", author: "Alex", flags: 2 },
+  ];
+
+  it("빈 리스트일 경우 emptyText를 출력한다", () => {
+    render(<ModerationQueue items={[]} onAction={jest.fn()} />);
+    expect(screen.getByText("No pending items")).toBeInTheDocument();
+  });
+
+  it("아이템이 있을 경우 제목/작성자/flags가 표시된다", () => {
+    render(<ModerationQueue items={items} onAction={jest.fn()} />);
+    expect(screen.getByText("은행 계좌 개설 팁")).toBeInTheDocument();
+    expect(screen.getByText(/by Hana · flags 3/)).toBeInTheDocument();
+    expect(screen.getByText("체류지 변경 후기")).toBeInTheDocument();
+  });
+
+  it("Approve 버튼 클릭 시 onAction이 호출된다", () => {
+    const mockAction = jest.fn();
+    render(<ModerationQueue items={items} onAction={mockAction} />);
+    fireEvent.click(screen.getByRole("button", { name: /Approve 은행 계좌 개설 팁/ }));
+    expect(mockAction).toHaveBeenCalledWith("p_1", "approve");
+  });
+
+  it("Hide/Remove 버튼도 각각 올바른 액션을 전달한다", () => {
+    const mockAction = jest.fn();
+    render(<ModerationQueue items={items} onAction={mockAction} />);
+    fireEvent.click(screen.getByRole("button", { name: /Hide 은행 계좌 개설 팁/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Remove 체류지 변경 후기/ }));
+    expect(mockAction).toHaveBeenCalledWith("p_1", "hide");
+    expect(mockAction).toHaveBeenCalledWith("p_2", "remove");
+  });
+});

--- a/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
+++ b/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
@@ -1,7 +1,7 @@
 /**
  * 모더레이션 액션 타입
  */
-export type ModerationAction = "approve" | "hide" | "remove";
+export type ModerationAction = 'approve' | 'hide' | 'remove';
 
 /**
  * 모더레이션 큐 아이템 도메인 모델
@@ -15,4 +15,17 @@ export interface IModerationItem {
   title: string;
   author: string;
   flags: number;
+}
+
+/**
+ * 컴포넌트 속성
+ * @param {ReadonlyArray<IModerationItem>} items - 화면에 표시할 모더레이션 아이템 목록, 읽기 전용 배열을 권장
+ * @param {(id:string, action:ModerationAction) => void} onAction - 각 아이템에 대한 액션 콜백, id - 대상 아이템의 식별자, action - 수행할 액션
+ * @param {string} emptyText - 항목이 없을 때 표시할 문구
+ */
+export interface IModerationQueueProps {
+  items: ReadonlyArray<IModerationItem>;
+  onAction: (id:string, action:ModerationAction) => void;
+  emptyText?: string;
+  className?: string;
 }

--- a/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
+++ b/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
@@ -1,7 +1,7 @@
 /**
  * 모더레이션 액션 타입
  */
-export type ModerationAction = 'approve' | 'hide' | 'remove';
+export type ModerationAction = "approve" | "hide" | "remove";
 
 /**
  * 모더레이션 큐 아이템 도메인 모델
@@ -25,7 +25,7 @@ export interface IModerationItem {
  */
 export interface IModerationQueueProps {
   items: ReadonlyArray<IModerationItem>;
-  onAction: (id:string, action:ModerationAction) => void;
+  onAction: (id: string, action: ModerationAction) => void;
   emptyText?: string;
   className?: string;
 }

--- a/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
+++ b/client/src/components/organisms/ModerationQueue/type/ModerationQueue.types.ts
@@ -1,0 +1,18 @@
+/**
+ * 모더레이션 액션 타입
+ */
+export type ModerationAction = "approve" | "hide" | "remove";
+
+/**
+ * 모더레이션 큐 아이템 도메인 모델
+ * @param {string} id - 고유 식별자
+ * @param {string} title - 게시물(또는 신고 대상) 제목
+ * @param {string} author - 작성자 표시명
+ * @param {number} flags - 누적 플래그/신고 횟수
+ */
+export interface IModerationItem {
+  id: string;
+  title: string;
+  author: string;
+  flags: number;
+}

--- a/client/src/components/organisms/SessionTable/SessionTable.tsx
+++ b/client/src/components/organisms/SessionTable/SessionTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { IDataTableColumn } from "@/components/molecules/DataTable/types/DataTable.types";
+import ISessionTableProps, { ISessionRow } from "./type/SessionTable.types";
+import { useMemo } from "react";
+import DataTable from "@/components/molecules/DataTable/DataTable";
+
+/**
+ * 관리자용 세션 목록 테이블
+ * @example
+ * const rows: ISessionRow[] = [
+ *  { id: 's_101', user: 'Hana', start: '09:12', pages: 7, last: '/course/intro', utm: 'google/brand' },
+ *  { id: 's_102', user: 'Alex', start: '14:03', pages: 3, last: '/community' },
+ * ];
+ *
+ * <SessionsTable
+ *   rows={rows}
+ *   onOpen={(id) => console.log('open session', id)}
+ *   caption="Recent sessions"
+ * />
+ */
+export default function SessionsTable({
+  rows,
+  onOpen,
+  caption = "User sessions",
+  className = "",
+}: ISessionTableProps) {
+  const columns: ReadonlyArray<IDataTableColumn<ISessionRow>> = useMemo(() => {
+    const base: IDataTableColumn<ISessionRow>[] = [
+      { key: "id", title: "Session" },
+      { key: "user", title: "User" },
+      { key: "start", title: "Start", align: "center" },
+      { key: "pages", title: "Pages", align: "center" },
+      { key: "last", title: "Last Path" },
+    ];
+    if (onOpen) {
+      base.push({
+        key: "id",
+        title: "Actions",
+        align: "center",
+        render: r => (
+          <button
+            type="button"
+            className="rounded-md bg-neutral-200 px-2 py-1 text-sm"
+            onClick={() => onOpen(r.id)}
+            aria-label={`Open session ${r.id}`}
+          >
+            Open
+          </button>
+        ),
+      });
+    }
+    return base;
+  }, [onOpen]);
+  return (
+    <div className={className}>
+      <DataTable<ISessionRow>
+        rows={rows}
+        columns={columns}
+        rowKey={r => r.id}
+        caption={caption}
+        stickyHeader
+      />
+    </div>
+  );
+}

--- a/client/src/components/organisms/SessionTable/__test__/SessionTable.test.tsx
+++ b/client/src/components/organisms/SessionTable/__test__/SessionTable.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { ISessionRow } from "../type/SessionTable.types";
+import SessionsTable from "../SessionTable";
+
+describe("SessionTable", () => {
+  const rows: ISessionRow[] = [
+    {
+      id: "s_101",
+      user: "Hana",
+      start: "09:12",
+      pages: 7,
+      last: "/course/intro",
+      utm: "google/brand",
+    },
+    { id: "s_102", user: "Alex", start: "14:03", pages: 3, last: "/community" },
+  ];
+
+  it("기본 열과 행이 렌더링되고, 캡션이 표시된다", () => {
+    render(<SessionsTable rows={rows} caption="Recent sessions" />);
+
+    // 캡션
+    expect(screen.getByText("Recent sessions")).toBeInTheDocument();
+
+    // 열 헤더 (Actions는 onOpen 없으면 나타나지 않음
+    expect(screen.getByText("Session")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
+    expect(screen.getByText("Start")).toBeInTheDocument();
+    expect(screen.getByText("Pages")).toBeInTheDocument();
+    expect(screen.getByText("Last Path")).toBeInTheDocument();
+    expect(screen.queryByText("Actions")).toBeNull();
+
+    // 행 데이터 (일부 셀 텍스트 확인)
+    expect(screen.getByText("Hana")).toBeInTheDocument();
+    expect(screen.getByText("Alex")).toBeInTheDocument();
+    expect(screen.getByText("09:12")).toBeInTheDocument();
+    expect(screen.getByText("14:03")).toBeInTheDocument();
+    expect(screen.getByText("/course/intro")).toBeInTheDocument();
+    expect(screen.getByText("/community")).toBeInTheDocument();
+    // pages는 숫자이므로 텍스트로도 나타나야 함
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("onOpen이 주어지면 Actions 열과 Open 버튼이 렌더링되고 클릭 시 콜백이 호출된다", () => {
+    const handleOpen = jest.fn();
+    render(<SessionsTable rows={rows} onOpen={handleOpen} />);
+
+    // Actions 헤더와 각 행의 Open 버튼 존재
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+
+    // 각 행에 Open 버튼이 하나씩
+    const openButtons = screen.getAllByRole("button", { name: /open/i });
+    expect(openButtons).toHaveLength(rows.length);
+
+    // 첫 번째 행의 버튼 클릭 -> 첫 번째 id로 콜백 호출
+    fireEvent.click(openButtons[0]);
+    expect(handleOpen).toHaveBeenCalledWith("s_101");
+
+    // 접근성 라벨도 부여됨
+    expect(screen.getByLabelText(`Open session ${rows[0].id}`)).toBeInTheDocument();
+  });
+
+  it("특정 행 내부에서 셀 텍스트를 찾을 수 있다(행 범위 검색 예시)", () => {
+    render(<SessionsTable rows={rows} />);
+
+    // "Hana"가 포함된 행을 찾아 그 안에서만 검증
+    const hanaCell = screen.getByText("Hana");
+    const hanaRow = hanaCell.closest("tr");
+    expect(hanaRow).not.toBeNull();
+
+    // 해당 행 내부에서 pages=7 과 last=/course/intro 를 확인
+    const scope = within(hanaRow as HTMLTableRowElement);
+    expect(scope.getByText("7")).toBeInTheDocument();
+    expect(scope.getByText("/course/intro")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/organisms/SessionTable/type/SessionTable.types.ts
+++ b/client/src/components/organisms/SessionTable/type/SessionTable.types.ts
@@ -1,0 +1,34 @@
+/**
+ * 세션 행 도메인 모델
+ *
+ * @interface
+ * @param {string} id - 세션 식별자
+ * @param {string} user - 사용자 표시명
+ * @param {string} start - 시작 시각
+ * @param {number} pages - 페이지뷰 수
+ * @param {string} last - 마지막 페이지 경로
+ * @param {string} utm - UTM 정보
+ */
+export interface ISessionRow {
+  id: string;
+  user: string;
+  start: string;
+  pages: number;
+  last: string;
+  utm?: string;
+}
+
+/**
+ * 컴포넌트 속성
+ *
+ * @interface
+ * @param {ReadonlyArray<ISessionRow>} rows - 렌더링할 세션 행 목록(불변 배열 권장)
+ * @param {(sessionId:string) => void} onOpen - 세션 행 클릭(열기) 콜백. 제공 시 Actions열이 노출된다. 선택된 세션의 ID
+ * @param {string} caption - 테이블 캡션(접근성용)
+ */
+export default interface ISessionTableProps {
+  rows: ReadonlyArray<ISessionRow>;
+  onOpen?: (sessionId: string) => void;
+  caption?: string;
+  className?: string;
+}

--- a/client/src/components/page/AdminPage/AdminPage.tsx
+++ b/client/src/components/page/AdminPage/AdminPage.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import AdminLayout from "@/components/features/AdminLayout/AdminLayout";
+import IAdminPageProps from "./type/AdminPage.types";
+import KPI from "@/components/atoms/KPI/KPI";
+import UserSearchPanel from "@/components/organisms/UserSearchPanel/UserSearchPanel";
+import SessionsTable from "@/components/organisms/SessionTable/SessionTable";
+import ChartPlaceholder from "@/components/molecules/ChartPlaceholder/ChartPlaceholder";
+import ModerationQueue from "@/components/organisms/ModerationQueue/ModerationQueue";
+
+/**
+ * 관리자 대시보드 페이지
+ * Next.js의 서버 컴포넌트에서 데이터를 불러와 주입하는 예시
+ * @example
+ * const users: IAdminUser[] = await fetchUsers();
+ * const sessions: ISessionRow[] = await fetchRecentSessions();
+ * const moderationQueue: IModerationItem[] = await fetchQueue();
+ * return <AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />;
+ */
+export function AdminPage({ users, sessions, moderationQueue }: IAdminPageProps) {
+  return (
+    <AdminLayout
+      title="Admin Dashboard"
+      subtitle="지난 7일 요약"
+      breadcrumbs={[{ label: "Home", href: "/" }, { label: "Admin" }]}
+      actions={
+        <div className="flex gap-2">
+          <button className="rounded-md bg-black px-3 py-1 text-white">Export</button>
+          <button className="rounded-md bg-neutral-200 px-3 py-1">Settings</button>
+        </div>
+      }
+    >
+      {/* KPIs */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KPI title="New Users" value="324" note="↑ 12%" />
+        <KPI title="Active Sessions" value="1,842" note="~ 12m avg" />
+        <KPI title="Conversion" value="4.6%" note="Free → Paid" />
+        <KPI title="Flags" value="18" note="need moderation" />
+      </div>
+
+      {/* Main grid */}
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <section aria-label="user search and actions">
+            <UserSearchPanel
+              users={users}
+              onView={id => console.log("view", id)}
+              onBan={id => console.log("ban", id)}
+              onUnban={id => console.log("unban", id)}
+            />
+          </section>
+
+          <section aria-label="recent sessions">
+            <SessionsTable
+              rows={sessions}
+              onOpen={sid => console.log("open session", sid)}
+              caption="Recent Sessions (joined to users)"
+            />
+          </section>
+        </div>
+
+        <div className="space-y-4">
+          <section aria-label="traffic">
+            <div className="rounded-2xl border bg-white p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-base font-semibold">Traffic (placeholder chart)</h3>
+              </div>
+              <ChartPlaceholder />
+            </div>
+          </section>
+
+          <section aria-label="moderation queue">
+            <div className="rounded-2xl border bg-white p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-base font-semibold">Moderation Queue</h3>
+              </div>
+              <ModerationQueue
+                items={moderationQueue}
+                onAction={(id, action) => console.log("moderate", id, action)}
+              />
+            </div>
+          </section>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/client/src/components/page/AdminPage/__test__/AdminPage.test.tsx
+++ b/client/src/components/page/AdminPage/__test__/AdminPage.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AdminPage } from "../AdminPage";
+
+// ---- 타입 임포트 (any 사용 금지) ----
+import { IAdminUser } from "@/components/organisms/UserSearchPanel/type/UserSearchPanel.types";
+import { ISessionRow } from "@/components/organisms/SessionTable/type/SessionTable.types";
+import {
+  IModerationItem,
+  IModerationQueueProps,
+} from "@/components/organisms/ModerationQueue/type/ModerationQueue.types";
+import { IAdminLayoutProps } from "@/components/features/AdminLayout/type/AdminLayout.types";
+import IUserSearchPanelProps from "@/components/organisms/UserSearchPanel/type/UserSearchPanel.types";
+import ISessionTableProps from "@/components/organisms/SessionTable/type/SessionTable.types";
+
+// ---- 자식 컴포넌트 목(mock) 정의 ----
+
+// AdminLayout: title/subtitle/children만 보여주는 가벼운 목
+jest.mock("@/components/features/AdminLayout/AdminLayout", () => {
+  const Mock: React.FC<IAdminLayoutProps> = ({ title, subtitle, children }) => (
+    <div data-testid="admin-layout">
+      <h1>{title}</h1>
+      {subtitle && <p>{subtitle}</p>}
+      <div data-testid="admin-layout-children">{children}</div>
+    </div>
+  );
+  return { __esModule: true, default: Mock };
+});
+
+// KPI: 단순 존재 확인용 목
+jest.mock("@/components/atoms/KPI/KPI", () => {
+  const Mock: React.FC<{ title: string; value: string; note?: string }> = ({
+    title,
+    value,
+    note,
+  }) => (
+    <div data-testid={`kpi-${title}`}>
+      {value}
+      {note ? `(${note})` : ""}
+    </div>
+  );
+  return { __esModule: true, default: Mock };
+});
+
+// UserSearchPanel: 패널 표시 + onView/onBan/onUnban 테스트용 버튼 제공
+jest.mock("@/components/organisms/UserSearchPanel/UserSearchPanel", () => {
+  const Mock: React.FC<IUserSearchPanelProps> = props => (
+    <div data-testid="user-search-panel">
+      <button onClick={() => props.onView("u1")}>mock-view</button>
+      <button onClick={() => props.onBan("u1")}>mock-ban</button>
+      <button onClick={() => props.onUnban("u1")}>mock-unban</button>
+    </div>
+  );
+  return { __esModule: true, default: Mock };
+});
+
+// SessionsTable: 테이블 표시 + onOpen 테스트용 버튼 제공
+jest.mock("@/components/organisms/SessionTable/SessionTable", () => {
+  const Mock: React.FC<ISessionTableProps> = props => (
+    <div data-testid="sessions-table">
+      <button onClick={() => props.onOpen?.("s1")}>mock-open-session</button>
+    </div>
+  );
+  return { __esModule: true, default: Mock };
+});
+
+// ChartPlaceholder: 단순 존재 확인
+jest.mock("@/components/molecules/ChartPlaceholder/ChartPlaceholder", () => {
+  const Mock: React.FC = () => <div data-testid="chart-placeholder" />;
+  return { __esModule: true, default: Mock };
+});
+
+// ModerationQueue: 큐 표시 + onAction 테스트용 버튼 제공
+jest.mock("@/components/organisms/ModerationQueue/ModerationQueue", () => {
+  const Mock: React.FC<IModerationQueueProps> = props => (
+    <div data-testid="moderation-queue">
+      <button onClick={() => props.onAction("m1", "approve")}>mock-moderate</button>
+    </div>
+  );
+  return { __esModule: true, default: Mock };
+});
+
+describe("AdminPage", () => {
+  const users: ReadonlyArray<IAdminUser> = [
+    { id: "u1", email: "alice@example.com", name: "Alice", status: "active" },
+    { id: "u2", email: "bob@example.com", name: "Bob", status: "banned" },
+  ];
+
+  const sessions: ReadonlyArray<ISessionRow> = [
+    { id: "s1", user: "Alice", start: "09:12", pages: 5, last: "/home" },
+    { id: "s2", user: "Bob", start: "10:20", pages: 3, last: "/settings" },
+  ];
+
+  const moderationQueue: ReadonlyArray<IModerationItem> = [
+    { id: "m1", title: "스팸 게시물", author: "Eve", flags: 4 },
+  ];
+
+  // console.log 스파이: AdminPage 내부 콜백(onView/onBan/onUnban/onOpen/onAction)이 제대로 호출되는지 확인
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  afterEach(() => {
+    logSpy.mockClear();
+  });
+
+  it("AdminLayout, KPI, UserSearchPanel, SessionsTable, ChartPlaceholder, ModerationQueue가 렌더링된다", () => {
+    render(<AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />);
+
+    // 레이아웃/헤더
+    expect(screen.getByTestId("admin-layout")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Admin Dashboard" })).toBeInTheDocument();
+    expect(screen.getByText("지난 7일 요약")).toBeInTheDocument();
+
+    // KPI 4개 (testid로 확인)
+    expect(screen.getByTestId("kpi-New Users")).toBeInTheDocument();
+    expect(screen.getByTestId("kpi-Active Sessions")).toBeInTheDocument();
+    expect(screen.getByTestId("kpi-Conversion")).toBeInTheDocument();
+    expect(screen.getByTestId("kpi-Flags")).toBeInTheDocument();
+
+    // 나머지 섹션
+    expect(screen.getByTestId("user-search-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("sessions-table")).toBeInTheDocument();
+    expect(screen.getByTestId("chart-placeholder")).toBeInTheDocument();
+    expect(screen.getByTestId("moderation-queue")).toBeInTheDocument();
+  });
+
+  it("UserSearchPanel 내부 액션이 AdminPage 콜백(= console.log)으로 전달된다", () => {
+    render(<AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />);
+
+    // view/ban/unban 각각 트리거
+    fireEvent.click(screen.getByText("mock-view"));
+    fireEvent.click(screen.getByText("mock-ban"));
+    fireEvent.click(screen.getByText("mock-unban"));
+
+    // AdminPage에서 정의한 콜백: console.log('view'|'ban'|'unban', id)
+    expect(logSpy).toHaveBeenCalledWith("view", "u1");
+    expect(logSpy).toHaveBeenCalledWith("ban", "u1");
+    expect(logSpy).toHaveBeenCalledWith("unban", "u1");
+  });
+
+  it("SessionsTable의 onOpen이 AdminPage 콜백(= console.log)으로 연결된다", () => {
+    render(<AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />);
+
+    fireEvent.click(screen.getByText("mock-open-session"));
+    expect(logSpy).toHaveBeenCalledWith("open session", "s1");
+  });
+
+  it("ModerationQueue의 onAction이 AdminPage 콜백(= console.log)으로 연결된다", () => {
+    render(<AdminPage users={users} sessions={sessions} moderationQueue={moderationQueue} />);
+
+    fireEvent.click(screen.getByText("mock-moderate"));
+    expect(logSpy).toHaveBeenCalledWith("moderate", "m1", "approve");
+  });
+});

--- a/client/src/components/page/AdminPage/type/AdminPage.types.ts
+++ b/client/src/components/page/AdminPage/type/AdminPage.types.ts
@@ -1,0 +1,16 @@
+import { IModerationItem } from "@/components/organisms/ModerationQueue/type/ModerationQueue.types";
+import { ISessionRow } from "@/components/organisms/SessionTable/type/SessionTable.types";
+import { IAdminUser } from "@/components/organisms/UserSearchPanel/type/UserSearchPanel.types";
+
+/**
+ * 관리자 대시보드 페이지에 주입할 초기 데이터 인터페이스
+ * @interface
+ * @param {ReadonlyArray<IAdminUser>} users - 사용자 목록(검색/벤/해제 대상)
+ * @param {ReadonlyArray<ISessionRow>} sessions - 최근 세션 목록(간이 표기)
+ * @param {ReadonlyArray<IModerationItem>} moderationQueue - 모더레이션 큐(승인/숨김/삭제 대상)
+ */
+export default interface IAdminPageProps {
+  users: ReadonlyArray<IAdminUser>;
+  sessions: ReadonlyArray<ISessionRow>;
+  moderationQueue: ReadonlyArray<IModerationItem>;
+}


### PR DESCRIPTION
- **feat(type)|SessionTable 인터페이스 구현**
- **feat(comp)|관리자용 세션 목록 테이블 컴포넌트**
- **test(comp)|SessionTable 컴포넌트 테스트**
- **feat(type)|모더레이션 큐 타입 정의**
- **feat(comp)|모더레이션 큐 제작**
- **test(comp)|모더레이션 큐 테스트**
- **i**
- **i**
- **feat(type)|관리자용 페이지 레이아웃 타입 정의**
- **feat(comp)|관리자용 페이지 레이아웃 제작**
- **test(comp)|관리자 레이아웃 단위 테스트**
- **chore(jest)|jest 모듈 이름 매퍼 설정 변경**
- **feat(type)|관리자 대시보드 페이지 타입 정의 추가**
- **feat(comp)|관리자 대시보드 페이지 컴포넌트 구현**
- **test(comp)|관리자페이지 테스트 추가**
- **feat(comp)|admin페이지 제작**
